### PR TITLE
Fix/table full height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hybr1d-ui",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/table/styles.module.css
+++ b/src/components/table/styles.module.css
@@ -37,6 +37,7 @@
   width: 100%;
   border-collapse: collapse;
   border: 1px solid var(--slate-200);
+  height: 100%;
 }
 
 .tableHead {


### PR DESCRIPTION
# Description

I wanted container inside table-cell to take full height, so added height: 100%
Reference: https://stackoverflow.com/questions/45179677/how-to-set-100-height-of-div-inside-table-cell

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (refactor or code cleanup)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected or a change which requires a backend deploy)
- [ ] Other (mention the change in the description)



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the patch version using pnpm
- [ ] My change follows the component API standard
